### PR TITLE
Add shares to Pool

### DIFF
--- a/packages/hardhat/contracts/Pool.sol
+++ b/packages/hardhat/contracts/Pool.sol
@@ -16,8 +16,8 @@ contract Pool {
   uint256 public totalShare = 0;
   mapping (address => uint256) shares;
 
-  constructor (address _token) {
-    token = ERC20(_token);
+  constructor (ERC20 _token) {
+    token = _token;
   }
 
   function deposit(uint256 amount) external returns (uint256 share) {

--- a/packages/hardhat/contracts/Pool.sol
+++ b/packages/hardhat/contracts/Pool.sol
@@ -1,24 +1,23 @@
 pragma solidity >=0.6.0 <0.9.0;
 //SPDX-License-Identifier: MIT
 
-import "./interfaces/IPool.sol";
-import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/SafeERC20.sol';
 import '@uniswap/v3-core/contracts/libraries/LowGasSafeMath.sol';
 import '@uniswap/v3-core/contracts/libraries/FullMath.sol';
 
-contract Pool is IPool {
-  using SafeERC20 for IERC20;
+contract Pool {
+  using SafeERC20 for ERC20;
   using LowGasSafeMath for uint256;
 
-  IERC20 public override token;
+  ERC20 token;
 
   uint256 public balance = 0;
   uint256 public totalShare = 0;
   mapping (address => uint256) shares;
 
-  constructor (IERC20 _token) {
-    token = _token;
+  constructor (address _token) {
+    token = ERC20(_token);
   }
 
   function deposit(uint256 amount) external returns (uint256 share) {
@@ -27,7 +26,7 @@ contract Pool is IPool {
 
     share = totalShare > 0
         ? FullMath.mulDiv(amount, totalShare, balance)
-        : amount.mul(1000000);
+        : amount.mul(10 ** (18 - token.decimals()));
 
     balance = balance.add(amount);
     totalShare = totalShare.add(share);

--- a/packages/hardhat/contracts/interfaces/IPool.sol
+++ b/packages/hardhat/contracts/interfaces/IPool.sol
@@ -2,10 +2,12 @@ pragma solidity >=0.6.0 <0.9.0;
 pragma abicoder v2;
 //SPDX-License-Identifier: MIT
 
-import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 
 interface IPool {
-    function token() external returns (IERC20);
+    function token() external returns (ERC20);
 
     function borrow(uint amount, address recipient) external;
+
+    function repay(uint amount, uint interest) external;
 }

--- a/packages/hardhat/contracts/stubs/PoolStub.sol
+++ b/packages/hardhat/contracts/stubs/PoolStub.sol
@@ -8,12 +8,16 @@ import "../interfaces/IPool.sol";
 
 contract PoolStub is IPool {
 
-    IERC20 public override token;
+    ERC20 public override token;
 
-    constructor(IERC20 _token) {
+    constructor(ERC20 _token) {
         token = _token;
     }
 
     function borrow(uint amount, address recipient) external override {
+    }
+
+    function repay(uint amount, uint interest) external override {
+
     }
 }

--- a/packages/hardhat/test/poolTest.ts
+++ b/packages/hardhat/test/poolTest.ts
@@ -57,6 +57,7 @@ describe("Pool", async () => {
       expect(await sut.balanceOf(lp1.address)).to.be.eq(utils.parseUnits("450"))
       expect(await sut.shareOf(lp1.address)).to.be.eq(utils.parseUnits("100", 0))
 
+      expect(await weth.balanceOf(sut.address)).to.be.eq(utils.parseUnits("450"))
       expect(await weth.balanceOf(lp1.address)).to.be.eq(utils.parseUnits("550"))
 
     })
@@ -73,6 +74,7 @@ describe("Pool", async () => {
       expect(await sut.shareOf(lp1.address)).to.be.eq(utils.parseUnits("33", 0))
       expect(await sut.shareOf(lp2.address)).to.be.eq(utils.parseUnits("66", 0))
 
+      expect(await weth.balanceOf(sut.address)).to.be.eq(utils.parseUnits("600"))
       expect(await weth.balanceOf(lp1.address)).to.be.eq(utils.parseUnits("800"))
       expect(await weth.balanceOf(lp2.address)).to.be.eq(utils.parseUnits("600"))
 
@@ -100,6 +102,7 @@ describe("Pool", async () => {
 
       await sut.connect(owner).depositFee(utils.parseUnits("100"))
       expect(await sut.balance()).to.be.eq(utils.parseUnits("700"))
+      expect(await weth.balanceOf(sut.address)).to.be.eq(utils.parseUnits("700"))
 
     })
 
@@ -170,6 +173,7 @@ describe("Pool", async () => {
       expect(await sut.balanceOf(lp1.address)).to.be.eq(utils.parseUnits("200"))
       expect(await sut.shareOf(lp1.address)).to.be.eq(utils.parseUnits("100", 0))
 
+      expect(await weth.balanceOf(sut.address)).to.be.eq(utils.parseUnits("200"))
       expect(await weth.balanceOf(lp1.address)).to.be.eq(utils.parseUnits("800"))
 
       // Withdrawal
@@ -178,6 +182,7 @@ describe("Pool", async () => {
       expect(await sut.balanceOf(lp1.address)).to.be.eq(utils.parseUnits("0"))
       expect(await sut.shareOf(lp1.address)).to.be.eq(utils.parseUnits("0"))
 
+      expect(await weth.balanceOf(sut.address)).to.be.eq(utils.parseUnits("0"))
       expect(await weth.balanceOf(lp1.address)).to.be.eq(utils.parseUnits("1000"))
 
     })
@@ -199,6 +204,7 @@ describe("Pool", async () => {
       expect(await sut.balanceOf(lp1.address)).to.be.eq(utils.parseUnits("300"))
       expect(await sut.shareOf(lp1.address)).to.be.eq(utils.parseUnits("100", 0))
 
+      expect(await weth.balanceOf(sut.address)).to.be.eq(utils.parseUnits("300"))
       expect(await weth.balanceOf(lp1.address)).to.be.eq(utils.parseUnits("700"))
 
     })


### PR DESCRIPTION
Now liquidity providers balance is calculated using their shares in the Pool.

repay will increase the balance of the pool, but it's not going to change the shares, which means that at the moment it's called, all the liquidity provider balances will be incremented in a ratio that depends on their share.

borrow+repay

Prop Test missing, next PR.