### PR TITLE
Add funds to test accounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "accounts": "yarn workspace @scaffold-eth/hardhat accounts",
     "balance": "yarn workspace @scaffold-eth/hardhat balance",
     "send": "yarn workspace @scaffold-eth/hardhat send",
+    "fund": "yarn workspace @scaffold-eth/hardhat fund",
     "ipfs": "yarn workspace @scaffold-eth/react-app ipfs",
     "surge": "yarn workspace @scaffold-eth/react-app surge",
     "s3": "yarn workspace @scaffold-eth/react-app s3",

--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -1,9 +1,11 @@
-import {HardhatUserConfig} from "hardhat/types";
-import {config as dotEnvConfig} from "dotenv";
-import 'hardhat-watcher';
+import {HardhatUserConfig} from 'hardhat/types'
+import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers'
+import {config as dotEnvConfig} from 'dotenv'
+import 'hardhat-watcher'
 
 // const { utils } = require("ethers");
-const fs = require("fs");
+const fs = require('fs')
+const R = require('ramda')
 // const chalk = require("chalk");
 //
 // require("@nomiclabs/hardhat-waffle");
@@ -11,11 +13,14 @@ const fs = require("fs");
 //
 // require("@nomiclabs/hardhat-etherscan");
 
-import "@nomiclabs/hardhat-waffle";
-import "@typechain/hardhat";
-import "@nomiclabs/hardhat-etherscan";
+import { task } from 'hardhat/config'
+import { parseEther } from 'ethers/lib/utils'
 
-dotEnvConfig();
+import "@nomiclabs/hardhat-waffle"
+import "@typechain/hardhat"
+import "@nomiclabs/hardhat-etherscan"
+
+dotEnvConfig()
 
 // const { isAddress, getAddress, formatUnits, parseUnits } = utils;
 
@@ -159,6 +164,19 @@ const config: HardhatUserConfig = {
 };
 
 export default config;
+
+task('fund', 'Add WETH and DAI to Test Accounts')
+  .setAction(async (taskArgs, { network, ethers }) => {
+
+    const signers = await ethers.getSigners()
+
+    console.log('Adding WETH to all Test Accounts')
+    const weth = await ethers.getContractAt('IWETH9', '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2')
+    for(let i = 0; i < signers.length; i++) {
+      await weth.connect(signers[i]).deposit({value: parseEther('1000')})
+    }
+
+  })
 
 // const DEBUG = false;
 //

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -58,6 +58,7 @@
     "balance": "hardhat balance",
     "send": "hardhat send",
     "generate": "hardhat generate",
-    "account": "hardhat account"
+    "account": "hardhat account",
+    "fund": "hardhat fund --network localhost"
   }
 }


### PR DESCRIPTION
Adds a new task to hardhat that adds WETH and DAI to all test accounts

with hardhat node running (yarn fork)
```
yarn fund
```

It will trade 1000 ETH => WETH, and then 10 WETH => DAI

![image](https://user-images.githubusercontent.com/768503/123881143-69257c80-d944-11eb-9337-2fd904d77960.png)

![image](https://user-images.githubusercontent.com/768503/123881196-7e9aa680-d944-11eb-9482-10b6ed1d2354.png)
